### PR TITLE
Implement trades_history for Kraken and improve the Trade Class

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -48,9 +48,10 @@ class Exchange(ABC):
 
 class Trade(object):
     """TODO: Check types"""
-    def __init__(self, asset_pair, price, volume):
+    def __init__(self, asset_pair, price, volume, time):
         self._asset_pair = asset_pair
         self._price = price
+        self._time = time
         self._volume = volume
 
     @property
@@ -62,7 +63,12 @@ class Trade(object):
         return self._price
 
     @property
+    def time(self):
+        return self._time
+
+    @property
     def volume(self):
         return self._volume
+
 
 from .kraken import Kraken

--- a/exchanges/kraken.py
+++ b/exchanges/kraken.py
@@ -1,4 +1,5 @@
 import requests
+import time
 
 from exchanges import Exchange, Trade
 
@@ -19,7 +20,7 @@ class Kraken(Exchange):
 
         ticker = self._public_query('Ticker', {'pair': [asset_pair]})
         price, volume = ticker[asset_pair]['c']
-        return Trade(asset_pair, price, volume)
+        return Trade(asset_pair, price, volume, time.time())
 
     def place_order(self, order):
         pass
@@ -27,8 +28,38 @@ class Kraken(Exchange):
     def order_info(self, order_id):
         pass
 
-    def trades_history(self, asset_pair, start_time, finish_time):
-        pass
+    def trades_history(self, asset_pair, since, until=None):
+        """Retrieves all the trades of an asset pair made between
+           two certain dates"""
+        # We can only retrieve the first 1000 trades made after a
+        # given date, so maybe we need to make multiple queries
+        # to obtain the desired period of time. Please note that
+        # the precision used in the 'since' parameter of the query
+        # is higher than the one used by unix
+        response = self._public_query('Trades', {'pair':asset_pair,
+                                                 'since':since*10**9})
+        trades = response[asset_pair]
+        next_id = int(response['last'])
+
+        if until is None:
+            until = until_kraken = next_id
+        else:
+            until_kraken = int(until*10**9)  # Kraken's timestamp precision
+ 
+        while next_id < until_kraken:
+            # The second time we make a query, we can use the
+            # 'last ID' of the previous query as the parameter 'since'.
+            # This is recommended in the api's documentation
+            response = self._public_query('Trades', {'pair':asset_pair,
+                                                     'since':next_id})
+            trades += response[asset_pair]
+            next_id = int(response['last'])
+
+        trades_history = [Trade(asset_pair, *(map(float, t[:3])))
+                          for t in trades if float(t[2]) <= until]
+        
+        return trades_history
+
 
     def _public_query(self, query_name, parameters=None):
         """Queries public data on Kraken"""

--- a/exchanges/tests/test_kraken.py
+++ b/exchanges/tests/test_kraken.py
@@ -74,8 +74,13 @@ class TestKraken(unittest.TestCase):
         # in a web browser we can create a specific test with only
         # 3 orders between 'since' and 'until'
         until = 1470092421.1177
+        gt_prices_volumes = [(538.05000, 1.07597000) ,(538.05000, 0.00020000),
+                             (538.05000, 0.05610236)]
         trades_history = kraken.trades_history(asset, since, until)
-        self.assertEqual(len(trades_history), 3)
+        for i, trade in enumerate(trades_history):
+            self.assertEqual(trade.asset_pair, asset)
+            self.assertEqual(trade.price, gt_prices_volumes[i][0])
+            self.assertEqual(trade.volume, gt_prices_volumes[i][1])
 
         until = 1470150000 # 16hs of diff.
         trades_history = kraken.trades_history(asset, since, until)

--- a/exchanges/tests/test_kraken.py
+++ b/exchanges/tests/test_kraken.py
@@ -50,3 +50,47 @@ class TestKraken(unittest.TestCase):
 
         # Querying a non existent asset pair should fail.
         self.assertRaises(RuntimeError, lambda: kraken.latest_trade('FAKE'))
+
+
+    def test_trades_history(self):
+        """Test the trades_history method"""
+
+        kraken = Kraken()
+
+        asset = 'XXBTZEUR'
+        since = 1470092400  # 2016-08-02 01:00:00 - unix timestamp
+        trades_history = kraken.trades_history(asset, since)
+
+        # The first was filled shortly after 'since'
+        tolerance = 10  # 10ms in unix timestamp
+        self.assertTrue(trades_history[0].time - since < tolerance)
+        self.assertEqual(len(trades_history), 1000)
+
+        # The rest are ordered
+        for i, trade in enumerate(trades_history[1:], 1):
+            self.assertTrue(trade.time > trades_history[i-1].time)
+
+        # By looking at /Trades?pair=XXBTZEUR&since=1470092400000000000
+        # in a web browser we can create a specific test with only
+        # 3 orders between 'since' and 'until'
+        until = 1470092421.1177
+        trades_history = kraken.trades_history(asset, since, until)
+        self.assertEqual(len(trades_history), 3)
+
+        until = 1470150000 # 16hs of diff.
+        trades_history = kraken.trades_history(asset, since, until)
+
+        # First and last within boundaries
+        self.assertTrue(len(trades_history) > 1000)
+        self.assertTrue(trades_history[0].time - since < tolerance)
+        self.assertTrue(until - trades_history[-1].time < tolerance)
+
+        # The rest are ordered
+        for i, trade in enumerate(trades_history[1:], 1):
+            self.assertTrue(trade.time > trades_history[i-1].time)
+
+        time.sleep(1)
+
+        # Querying a non existent asset pair should fail.
+        self.assertRaises(RuntimeError, lambda: kraken.trades_history('FAKE',
+                                                                      123456))


### PR DESCRIPTION
In this commit I implemented the trades_history
for the kraken exchange. A test for the method
was also added. An important change made during
this commit is the addition of the parameter
time to the class Trade. This not only allows
to simplify the implementation of trades_history
but also helps to better characterize a trade.