### PR TITLE
Implement order_info for the kraken exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the data folder with private data.
+data/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -1,4 +1,8 @@
 from abc import ABC, abstractmethod
+import os
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+PRIVATE_DATA_DIR = os.path.join(DATA_DIR, 'private')
 
 
 class Balance(object):
@@ -44,6 +48,16 @@ class Exchange(ABC):
     def trades_history(self, asset_pair, start_time, finish_time):
         """Retrieves the trades made between the supplied time interval"""
         pass
+
+
+class OrderInformation(object):
+    """TODO: Check types"""
+    def __init__(self, status):
+        self._status = status
+
+    @property
+    def status(self):
+        return self._status
 
 
 class Trade(object):

--- a/exchanges/kraken.py
+++ b/exchanges/kraken.py
@@ -60,8 +60,10 @@ class Kraken(Exchange):
         """Queries private data on Kraken"""
 
         if self.public_key is None or self.private_key is None:
-            raise ValueError('Querying the private user '
-                             'data requires an API key.')
+            raise ValueError('Querying the private user data requires '
+                             'an API key. Please add your public and private '
+                             'keys to the file '
+                             '\'exchanges/data/private/kraken-key\'.')
 
         nonce = int(1000 * time.time())
 

--- a/exchanges/kraken.py
+++ b/exchanges/kraken.py
@@ -1,6 +1,12 @@
+import base64
+import hashlib
+import hmac
+import os
 import requests
+import time
+import urllib.parse
 
-from exchanges import Exchange, Trade
+from exchanges import Exchange, OrderInformation, PRIVATE_DATA_DIR, Trade
 
 
 class Kraken(Exchange):
@@ -8,6 +14,20 @@ class Kraken(Exchange):
     def __init__(self):
         self.timeout = 5.0
         self.url = 'https://api.kraken.com/0/'
+
+        # Load the API keys from the data folder.
+        key_file = os.path.join(PRIVATE_DATA_DIR, 'kraken-key')
+        if os.path.exists(key_file):
+            with open(key_file, 'rt') as f:
+                self.public_key = f.readline().rstrip()
+                self.private_key = f.readline().rstrip()
+        else:
+            raise Warning('The Kraken API requires an API key to access '
+                          'private user data. Please add your public '
+                          'and private keys to the file '
+                          '\'exchanges/data/private/kraken-key\'.')
+            self.public_key = None
+            self.privage_key = None
 
     def server_time(self):
         """Queries the current server time (unix time stamp)"""
@@ -19,16 +39,62 @@ class Kraken(Exchange):
 
         ticker = self._public_query('Ticker', {'pair': [asset_pair]})
         price, volume = ticker[asset_pair]['c']
+
         return Trade(asset_pair, price, volume)
 
     def place_order(self, order):
         pass
 
     def order_info(self, order_id):
-        pass
+        """Queries information about an order"""
+
+        info = self._private_query('QueryOrders', {'txid': order_id})
+        order_info = OrderInformation(info[order_id]['status'])
+
+        return order_info
 
     def trades_history(self, asset_pair, start_time, finish_time):
         pass
+
+    def _private_query(self, query_name, data=None):
+        """Queries private data on Kraken"""
+
+        if self.public_key is None or self.private_key is None:
+            raise ValueError('Querying the private user '
+                             'data requires an API key.')
+
+        nonce = int(1000 * time.time())
+
+        url = '{}private/{}'.format(self.url, query_name)
+        uri = '/0/private/{}'.format(query_name)
+
+        if data is None:
+            data = {}
+        data['nonce'] = nonce
+
+        # Encode the POST data using Kraken's scheme.
+        post_data = urllib.parse.urlencode(data)
+        data_nonce = (str(nonce) + post_data).encode()
+        message = uri.encode() + hashlib.sha256(data_nonce).digest()
+        signature = hmac.new(base64.b64decode(self.private_key), message,
+                             hashlib.sha512)
+        signature_digest = base64.b64encode(signature.digest()).decode()
+
+        # Request private data. This can raise an exception
+        # if there is a connection error or if the request times
+        # out. In addition, raise an exception if the status is not
+        # OK.
+        headers = {'API-Key': self.public_key, 'API-Sign': signature_digest}
+        response = requests.post(url, headers=headers, data=post_data,
+                                 timeout=self.timeout)
+        response.raise_for_status()
+
+        json = response.json()
+
+        if len(json['error']) > 0:
+            raise RuntimeError(json['error'][0])
+
+        return json['result']
 
     def _public_query(self, query_name, parameters=None):
         """Queries public data on Kraken"""


### PR DESCRIPTION
This commit implements the `order_info` method for the Kraken exchange. Because this is the first method that requires access to private user data, a helper method `_private_query` was also added. In addition, facilities to store and retrieve the API key of the user were added.

The `order_info` method returns an instance of `OrderInformation` which is a placeholder. Full order information will be added in the future.